### PR TITLE
update logger.warn to logger.warning

### DIFF
--- a/lib/google_recaptcha/application.ex
+++ b/lib/google_recaptcha/application.ex
@@ -161,7 +161,7 @@ defmodule GoogleRecaptcha.Application do
              if attempts > unquote(retries) do
                require Logger
 
-               Logger.warn(fn -> "GoogleRecaptcha: Request Failed: #{inspect(err)}" end,
+               Logger.warning(fn -> "GoogleRecaptcha: Request Failed: #{inspect(err)}" end,
                  error: err
                )
 


### PR DESCRIPTION
logger.warn is deprecated. it can change from warn to warning and the functionality will be the same